### PR TITLE
Revert "Added Discord link"

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,6 @@ title: HaCS - Hackathon and Computing Society at BCU
           <a href="#committe"><li>Committee <div class="nav-line"></div></li></a>
           <a href="https://www.bcusu.com/organisation/9907/"><li>Membership <div class="nav-line"></div></li></a>
           <a href="https://hacsbcu.moodlecloud.com"><li>Workshops <div class="nav-line"></div></li></a>
-          <a href="https://discord.gg/M88aTss"><li>Discord <div class="nav-line"></div></li></a>
         </ul>
       </div>
         <div class="mobile-nav-container" role="static">
@@ -43,7 +42,6 @@ title: HaCS - Hackathon and Computing Society at BCU
               <a href="#committe"><li>Committee <div class="nav-line"></div></li></a>
               <a href="https://www.bcusu.com/organisation/9907/"><li>Membership <div class="nav-line"></div></li></a>
               <a href="https://hacsbcu.moodlecloud.com"><li>Workshops <div class="nav-line"></div></li></a>
-              <a href="https://discord.gg/M88aTss"><li>Discord <div class="nav-line"></div></li></a>
             </ul>
           </div>
         </div>
@@ -55,7 +53,6 @@ title: HaCS - Hackathon and Computing Society at BCU
             <a href="#committe"><li>Committee <div class="nav-line"></div></li></a>
             <a href="https://www.bcusu.com/organisation/9907/"><li>Membership <div class="nav-line"></div></li></a>
             <a href="https://hacsbcu.moodlecloud.com"><li>Workshops <div class="nav-line"></div></li></a>
-            <a href="https://discord.gg/M88aTss"><li>Discord <div class="nav-line"></div></li></a>
           </ul>
         </div>
         <div id="header-logo">


### PR DESCRIPTION
Reverts HaCSBCU/hacsbcu.github.io#80

I reverted this because the website is public facing meaning anyone could join - maybe not such a good idea...