### PR TITLE
Add TravisBuddy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,7 @@ env:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer
 
 sudo: false # route your build to the container-based infrastructure for a faster build
+
+notifications:
+    webhooks: https://www.travisbuddy.com/
+    

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ sudo: false # route your build to the container-based infrastructure for a faste
 
 notifications:
     webhooks: https://www.travisbuddy.com/
-    
+    on_success: never


### PR DESCRIPTION
TravisBuddy will automatically add Travis CI build errors as comments on relevant PRs. Thanks to @PandelisZ for the idea - I saw your fork on my feed. 